### PR TITLE
CDPT-163 Add all tables and views for metabase user

### DIFF
--- a/products/correspondence_tool_staff/create_ready_only_users.sql
+++ b/products/correspondence_tool_staff/create_ready_only_users.sql
@@ -10,7 +10,9 @@ GRANT readaccess TO <user_name>;
 -- How to create read-only user on live replication environment
 CREATE ROLE branson_read_access;
 GRANT USAGE ON SCHEMA public TO branson_read_access;
-GRANT SELECT ON data_requests, warehouse_case_report_for_offender_sar_related, offender_subject_type_volume_view, offender_sar_vetting_track_view, offender_data_requests_volume_view TO branson_read_access;
+GRANT SELECT ON cases_outcome_reasons, category_references, retention_schedules, tmp_partial_cases, data_requests,
+  offender_subject_type_volume_view, offender_sar_vetting_track_view, offender_data_requests_volume_view,
+  warehouse_case_report_for_london_disclosure_related, warehouse_case_report_for_offender_sar_related TO branson_read_access;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO branson_read_access;
 GRANT CONNECT ON DATABASE '<database name>' to branson_read_access;
 create user "<user_name>" with password '<password>';


### PR DESCRIPTION
The user that metabase uses to access the live replica database has the role `branson_read_access`.

This user requires access to the new view `warehouse_case_report_for_london_disclosure_related` that was added in https://github.com/ministryofjustice/dex_mi_metabase/pull/7.

There are also a few tables that this user already has access to that are not reflected in the current SQL. Those tables have also been added (`cases_outcome_reasons`, `category_references`, `retention_schedules`, `tmp_partial_cases`)