### PR TITLE
Add Rejected Offender SAR case type to WHERE

### DIFF
--- a/products/correspondence_tool_staff/views.sql
+++ b/products/correspondence_tool_staff/views.sql
@@ -92,7 +92,7 @@
             ELSE 'Third party'::text
         END AS requester_from
    FROM warehouse_case_reports
-  WHERE warehouse_case_reports.case_type::text = ANY (ARRAY['Offender SAR'::character varying::text,'Rejected Offender SAR'::character varying::text, 'Complaint - Standard'::character varying::text, 'Complaint - ICO'::character varying::text, 'Complaint - Litigation'::character varying::text]);
+  WHERE warehouse_case_reports.case_type::text = ANY (ARRAY['Offender SAR'::character varying::text, 'Rejected Offender SAR'::character varying::text, 'Complaint - Standard'::character varying::text, 'Complaint - ICO'::character varying::text, 'Complaint - Litigation'::character varying::text]);
 
 
  -- offender_data_requests_volume_view


### PR DESCRIPTION
The view "warehouse_case_report_for_offender_sar_related" was missing the case_type for Rejected Offender SAR in the WHERE clause