### PR TITLE
Metabase minor version upgrade

### DIFF
--- a/kubernetes/production/deployment.yaml
+++ b/kubernetes/production/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: webapp
-          image: metabase/metabase:v0.41.4
+          image: metabase/metabase:v0.41.9
           imagePullPolicy: IfNotPresent
           env:
           - name: MB_DB_TYPE


### PR DESCRIPTION
Latest 0.41.X open source release is 0.41.9 - https://www.metabase.com/docs/v0.49/releases - https://github.com/metabase/metabase/releases/tag/v0.41.9
