### PR TITLE
Major Metabase upgrade from 0.41.9 to 0.49.9

### DIFF
--- a/kubernetes/production/deployment.yaml
+++ b/kubernetes/production/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: webapp
-          image: metabase/metabase:v0.41.9
+          image: metabase/metabase:v0.49.9
           imagePullPolicy: IfNotPresent
           env:
           - name: MB_DB_TYPE


### PR DESCRIPTION
Currently at version 0.41.9, this upgrade takes it to the latest open source version - https://github.com/metabase/metabase/releases/tag/v0.49.9