### PR TITLE
Downgrade to 0.48.12

### DIFF
--- a/kubernetes/production/deployment.yaml
+++ b/kubernetes/production/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: webapp
-          image: metabase/metabase:v0.49.9
+          image: metabase/metabase:v0.48.12
           imagePullPolicy: IfNotPresent
           env:
           - name: MB_DB_TYPE


### PR DESCRIPTION
The previous upgrade to 0.49.9 resulted in a pod error caused by migrations/001_update_migrations.yaml::v49.2024-04-09T10:00:03. See whether omitting the latest v49 migrations will avoid the error.