### PR TITLE
Back to 0.49.9 to start downgrade

### DIFF
--- a/kubernetes/production/deployment.yaml
+++ b/kubernetes/production/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: webapp
-          image: metabase/metabase:v0.48.12
+          image: metabase/metabase:v0.49.9
           imagePullPolicy: IfNotPresent
           env:
           - name: MB_DB_TYPE


### PR DESCRIPTION
Trying to downgrade the Metabase instance before downgrading the DB causes an error.