### PR TITLE
CDPT-1952 Enable modsec detection mode on production

### DIFF
--- a/kubernetes/production/ingress-live.yaml
+++ b/kubernetes/production/ingress-live.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: dex-mi-production-metabase-ingress
+  name: dex-mi-production-metabase-ingress-modsec
   namespace: dex-mi-production
   annotations:
     nginx.ingress.kubernetes.io/server-snippet: |
@@ -11,7 +11,7 @@ metadata:
       location ~* \.(php|cgi)$ {
         deny all; access_log off;
       }
-    external-dns.alpha.kubernetes.io/set-identifier: dex-mi-production-metabase-ingress-dex-mi-production-green
+    external-dns.alpha.kubernetes.io/set-identifier: dex-mi-production-metabase-ingress-modsec-dex-mi-production-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |


### PR DESCRIPTION
## Description
Enables [modsec](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/networking/modsecurity.html) in detection mode on production so we can be aware of any issues and evaluate if more protection is required.