### PR TITLE
Add staging deploy files

### DIFF
--- a/kubernetes/staging/configmap.yaml
+++ b/kubernetes/staging/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data:
+  ENV: 'staging'
+  RAILS_ENV: 'staging'
+  RAILS_SERVE_STATIC_FILES: 'true'
+  SENTRY_ENVIRONMENT: 'staging'
+kind: ConfigMap
+metadata:
+  name: environment-variables

--- a/kubernetes/staging/deployment.yaml
+++ b/kubernetes/staging/deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dex-mi-staging-metabase-deployment
+  namespace: dex-mi-staging
+spec:
+  replicas: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  selector:
+    matchLabels:
+      app: dex-mi-staging-metabase-webapp
+  template:
+    metadata:
+      labels:
+        app: dex-mi-staging-metabase-webapp
+        tier: frontend
+    spec:
+      containers:
+        - name: webapp
+          image: metabase/metabase:v0.48.12
+          imagePullPolicy: IfNotPresent
+          # Set this if an upgrade ever fails and you need to downgrade
+          # args: ["migrate down"]
+          env:
+          - name: MB_DB_TYPE
+            value: "postgres"
+          - name: MB_DB_CONNECTION_URI
+            valueFrom:
+              secretKeyRef:
+                name: dex-mi-staging-rds-output
+                key: url
+          envFrom:
+            - configMapRef:
+                name: environment-variables
+          ports:
+            - containerPort: 3000
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 120
+            timeoutSeconds: 5
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 30
+            timeoutSeconds: 3
+            periodSeconds: 5
+      securityContext:
+        runAsUser: 1000
+        fsGroup: 1000

--- a/kubernetes/staging/ingress-live.yaml
+++ b/kubernetes/staging/ingress-live.yaml
@@ -1,0 +1,36 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dex-mi-staging-metabase-ingress-modsec
+  namespace: dex-mi-staging
+  annotations:
+    nginx.ingress.kubernetes.io/server-snippet: |
+      location = /.well-known/security.txt {
+        return 301 https://raw.githubusercontent.com/ministryofjustice/security-guidance/main/contact/vulnerability-disclosure-security.txt;
+      }
+      location ~* \.(php|cgi)$ {
+        deny all; access_log off;
+      }
+    external-dns.alpha.kubernetes.io/set-identifier: dex-mi-staging-metabase-ingress-modsec-dex-mi-staging-green
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecAuditEngine On
+      SecRuleEngine DetectionOnly
+      SecDefaultAction "phase:2,pass,log,tag:github_team=central-digital-product-team,tag:namespace=dex-mi-staging"
+spec:
+  ingressClassName: modsec
+  tls:
+  - hosts:
+    - dex-mi-staging.apps.live.cloud-platform.service.justice.gov.uk
+  rules:
+  - host: dex-mi-staging.apps.live.cloud-platform.service.justice.gov.uk
+    http:
+      paths:
+      - path: /
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: dex-mi-staging-metabase-service
+            port:
+              number: 3000

--- a/kubernetes/staging/service.yaml
+++ b/kubernetes/staging/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dex-mi-staging-metabase-service
+  namespace: dex-mi-staging
+  labels:
+    app: dex-mi-staging-metabase-webapp
+spec:
+  ports:
+  - port: 3000
+    name: http
+    targetPort: 3000
+  selector:
+    app: dex-mi-staging-metabase-webapp


### PR DESCRIPTION
Add staging deploy files for purpose of testing. Used during the Amazon SES test setup. We may also need to update Metabase as it is several versions behind, so can use this for testing then.

There is no deploy workflow for staging, to deploy, please apply files manually to `dex-mi-staging` namespace.