### PR TITLE
CDPTKAN-1305 Verify deploys actually land the intended image version

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,18 @@ To run it:
 
 On failure it prints the container logs and exits non-zero, leaving nothing behind to clean up.
 
+### Verifying a deploy
+
+`deploy.sh` runs [`local/verify-deploy.sh`](local/verify-deploy.sh) automatically after every `kubectl apply`, polling the deployed instance's public `/api/health` and `/api/session/properties` endpoints until it's consistently reporting the version just deployed. This is read-only (no login, no state changes), so it's safe against staging or production.
+
+It's needed because production runs a zero-downtime rolling update (`maxUnavailable: 0`) across 2 replicas: `/api/health` stays green for the entire rollout since old pods keep serving traffic, so a single successful health check proves nothing about whether the new image actually landed. The script instead waits for 3 consecutive checks to agree on the expected version tag, which only happens once every old pod has been replaced.
+
+To run it standalone, e.g. to check a deploy that's already finished:
+```
+./local/verify-deploy.sh https://dex-mi-production.apps.live.cloud-platform.service.justice.gov.uk v0.58.24
+```
+Requires `curl` and `jq`.
+
 ## TODO list
 - Create a docker image based on the metabase image, then we can install some tools we want for our own usage
 - Write a script to export/import the dashboard and reports from different servers

--- a/deploy.sh
+++ b/deploy.sh
@@ -21,7 +21,7 @@ function _deploy() {
   Usage: ./deploy.sh environment
   Where:
     environment - one of staging|production
-  Requires: kubectl, envsubst (part of the gettext package)
+  Requires: kubectl, envsubst (part of the gettext package), curl, jq
   Example:
     # build the app to get an image tag
     ./build.sh
@@ -109,6 +109,10 @@ function _deploy() {
     -f kubernetes/${environment}/ingress-live.yaml \
     -f kubernetes/${environment}/secrets.yaml \
     -n $namespace
+
+  # Confirm the rollout actually landed the intended image before declaring victory
+  metabase_url="https://dex-mi-${environment}.apps.live.cloud-platform.service.justice.gov.uk"
+  ./local/verify-deploy.sh "$metabase_url" "$METABASE_VERSION"
 }
 
 _deploy $@

--- a/local/verify-deploy.sh
+++ b/local/verify-deploy.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Verifies a deployed Metabase instance is up and running the expected
+# image version, by polling the public /api/health and
+# /api/session/properties endpoints. Read-only: makes no authenticated
+# requests and changes nothing on the target instance, so it's safe to run
+# against staging or production.
+#
+# Usage: ./local/verify-deploy.sh <url> <expected-version> [timeout-seconds]
+#   url               e.g. https://dex-mi-production.apps.live.cloud-platform.service.justice.gov.uk
+#   expected-version  e.g. v0.58.24 (as it appears in .metabase_version)
+#   timeout-seconds   defaults to 300 (rolling updates can take a few minutes)
+
+set -euo pipefail
+
+log() { printf '\033[33m%s\033[0m\n' "$1"; }
+fail() { printf '\033[31m%s\033[0m\n' "$1" >&2; exit 1; }
+
+[ $# -ge 2 ] || fail "Usage: $0 <url> <expected-version> [timeout-seconds]"
+
+URL="${1%/}"
+EXPECTED_VERSION="$2"
+TIMEOUT_SECS="${3:-300}"
+
+for bin in curl jq; do
+  command -v "$bin" >/dev/null 2>&1 || fail "Fatal: '$bin' is required but not installed."
+done
+
+log "--------------------------------------------------"
+log "Verifying deploy: ${URL} (expecting ${EXPECTED_VERSION})"
+log "--------------------------------------------------"
+
+# With replicas > 1 and a zero-downtime RollingUpdate, /api/health stays
+# green throughout the rollout while the load balancer still spreads
+# requests across old and new pods, so a single passing check proves
+# nothing. Poll until several consecutive requests agree on the new
+# version, which only happens once every old pod has been replaced.
+REQUIRED_CONSECUTIVE_MATCHES=3
+consecutive_matches=0
+elapsed=0
+last_seen_version=""
+
+log "Waiting for all pods to report ${EXPECTED_VERSION} (timeout ${TIMEOUT_SECS}s)..."
+while [ "$consecutive_matches" -lt "$REQUIRED_CONSECUTIVE_MATCHES" ]; do
+  if [ "$elapsed" -ge "$TIMEOUT_SECS" ]; then
+    fail "Timed out after ${TIMEOUT_SECS}s waiting for all pods to report '${EXPECTED_VERSION}' (last seen: '${last_seen_version:-none}'). The rollout may still be in progress, stuck, or running the wrong image."
+  fi
+
+  if curl -sf "${URL}/api/health" >/dev/null 2>&1; then
+    last_seen_version=$(curl -sf "${URL}/api/session/properties" | jq -r '.version.tag // empty')
+    if [ "$last_seen_version" = "$EXPECTED_VERSION" ]; then
+      consecutive_matches=$((consecutive_matches + 1))
+    else
+      consecutive_matches=0
+    fi
+  else
+    consecutive_matches=0
+  fi
+
+  sleep 5
+  elapsed=$((elapsed + 5))
+done
+
+log "Deploy verified: ${URL} is healthy and consistently running ${EXPECTED_VERSION}."


### PR DESCRIPTION
- Add `local/verify-deploy.sh`, a read-only script that polls a deployed Metabase instance's public `/api/health` and `/api/session/properties` endpoints until 3 consecutive checks agree on the expected version tag, then exits non-zero with the version it actually saw if it times out.                                          
- Wire it into `deploy.sh`, running automatically after every `kubectl apply` against  `https://dex-mi-${environment}.apps.live.cloud-platform.service.justice.gov.uk`, so a deploy only reports success once the new image has actually rolled out everywhere — not just once the endpoint responds.                                                                                                                    

- This matters because production runs a zero-downtime `RollingUpdate` (`maxUnavailable: 0`, 2 replicas): `/api/health` stays green for the entire rollout since old pods keep serving traffic, so a single passing health check right after `kubectl apply` proves nothing about whether the new image landed. Polling for a *consistent* version match is what actually confirms the rollout finished.                                                                                                        
 - Document the verification step and standalone usage in the README.